### PR TITLE
Removing extra reference to sketch.js fixes #1

### DIFF
--- a/body_classifier_recorded/index.html
+++ b/body_classifier_recorded/index.html
@@ -10,9 +10,6 @@
 	<script src="https://unpkg.com/ml5@0.1.1/dist/ml5.min.js" type="text/javascript"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.1/p5.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.6.1/addons/p5.dom.min.js"></script>
-
-	<script src="sketch.js"></script>
-
 </head>
 <body>
   <h1>PoseNet classifier example using p5.js</h1>


### PR DESCRIPTION
The `testLive already declared` error is due to `sketch.js` being referenced twice in `index.html` by accident. Love this example! ❤️  